### PR TITLE
quote the CSV array column

### DIFF
--- a/fits2db.c
+++ b/fits2db.c
@@ -1357,7 +1357,7 @@ dl_printSQLHdr (char *tablename, fitsfile *fptr, int firstcol, int lastcol,
         if (format == TAB_POSTGRES) {
             fprintf (ofd, "\nCOPY %s (", tablename);
             dl_printHdr (firstcol, lastcol, ofd);
-            fprintf (ofd, ") FROM stdin DELIMITER '%c';\n", delimiter);
+	    fprintf (ofd, ") FROM stdin CSV DELIMITER '%c';\n", delimiter);
         } else if (format == TAB_MYSQL || format == TAB_SQLITE) {
             fprintf (ofd, "\nINSERT INTO %s (", tablename);
             dl_printHdr (firstcol, lastcol, ofd);
@@ -1519,8 +1519,9 @@ dl_printCol (unsigned char *dp, ColPtr col, char end_char)
             *optr++ = quote_char, *optr++ = '(';
             olen += 2;
         } else {
-            *optr++ = '{';
-            olen += 1;
+	    memcpy (optr, "\"{", 2);
+	    optr += 2;
+            olen += 2;
         }
     }
 
@@ -1588,8 +1589,9 @@ dl_printCol (unsigned char *dp, ColPtr col, char end_char)
             *optr++ = quote_char, *optr++ = ')';
             olen += 2;
         } else {
-            *optr++ = '}';
-            olen += 1;
+	    memcpy (optr, "}\"", 2);
+	    optr += 2;
+            olen += 2;
         }
     }
 


### PR DESCRIPTION
fits2db supports CSV column arrays. For it to work with a COPY command the array needs to be quoted, otherwise it thinks it has more columns than the specified and raises an error.